### PR TITLE
Fix #108 by selecting budget from its id instead of its title

### DIFF
--- a/resources/assets/js/budget-selector.js
+++ b/resources/assets/js/budget-selector.js
@@ -51,7 +51,7 @@
 
                         // check if we can preselect the dropdown as it was previously or with one from the same account budget
                         if (parseInt(dropdown.attr('data-budget-id')) == element.id || parseInt(dropdown.attr('data-account-budget-id')) == element.account_budget_id) {
-                            selected = element.title;
+                            selected = element.id;
                         }
 
                         // append option to dropdown items


### PR DESCRIPTION
This is necessary to make sure the auto selection is made even with items contains non alphanumeric character. Being based on the id prevent mal functionning.

Although, this could become a problem if budgets have a numeric value as their name, which appears to be in the same budget list. This would be rare but could happen. Maybe consider applying a validation rule on the budget title so it can't only be numbers.